### PR TITLE
Fix case where stdlib is shadowed

### DIFF
--- a/flake8_import_order/__init__.py
+++ b/flake8_import_order/__init__.py
@@ -135,14 +135,15 @@ class ImportVisitor(ast.NodeVisitor):
         if pkg == "__future__":
             return IMPORT_FUTURE
 
-        elif pkg in STDLIB_NAMES:
-            return IMPORT_STDLIB
-
         elif (
             pkg in self.application_import_names or
             (isinstance(node, ast.ImportFrom) and node.level > 0)
         ):
             return IMPORT_APP
+
+        elif pkg in STDLIB_NAMES:
+            return IMPORT_STDLIB
+
         else:
             # Not future, stdlib or an application import.
             # Must be 3rd party.

--- a/tests/test_cases/stdlib_shadowing.py
+++ b/tests/test_cases/stdlib_shadowing.py
@@ -1,0 +1,2 @@
+from .filesystem import FilesystemStorage
+from .http import HttpStorage


### PR DESCRIPTION
While it might not be a good idea, the code presented in the testcase does
obviously not refer to the stdlib http module, but gets detected as as stdlib
import. This pull request prioritizes relative imports over stdlib ones, as
Python's import system does.
