### PR TITLE
Fix error format for relative imports

### DIFF
--- a/flake8_import_order/__init__.py
+++ b/flake8_import_order/__init__.py
@@ -208,12 +208,16 @@ class ImportOrderChecker(object):
                 continue
 
             if n < pn:
-                first_str = (
-                    ("from " if k[2] >= 0 else "import ") + ", ".join(k[1])
-                )
-                second_str = (
-                    ("from " if pk[2] >= 0 else "import ") + ", ".join(pk[1])
-                )
+                def build_str(key):
+                    level = key[2]
+                    if level >= 0:
+                        start = "from " + level * '.'
+                    else:
+                        start = "import "
+                    return start + ", ".join(key[1])
+
+                first_str = build_str(k)
+                second_str = build_str(pk)
 
                 yield self.error(
                     node, "I100",


### PR DESCRIPTION
Hi there, thank-you for this great time-saving library!

I've made a little tweak to improve the output text for relative imports, and hope you find it useful `:)`

I'm sorry that I have not written a test for this, I was unable to really get to grips with how they work, but here is a before and after screenshot:

Before:
![screenshot from 2014-10-13 10 46 50](https://cloud.githubusercontent.com/assets/767671/4611849/7e266620-52bf-11e4-9856-bb57ab647baf.png)

After:
![screenshot from 2014-10-13 10 47 05](https://cloud.githubusercontent.com/assets/767671/4611850/83c52a08-52bf-11e4-8100-9e47ab7a63fa.png)

(I am still investigating why I am being told both `. should be before ..` and `.. should be before .`)
