### PR TITLE
Add compatibility with Flake8 3.0

### DIFF
--- a/flake8_import_order/flake8_linter.py
+++ b/flake8_import_order/flake8_linter.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import optparse
+
 import flake8_import_order
 from flake8_import_order import DEFAULT_IMPORT_ORDER_STYLE, ImportOrderChecker
 
@@ -14,29 +16,35 @@ class Linter(ImportOrderChecker):
     @classmethod
     def add_options(cls, parser):
         # List of application import names. They go last.
-        parser.add_option(
+        register_opt(
+            parser,
             "--application-import-names",
             default="",
             action="store",
             type="string",
-            help="Import names to consider as application specific"
+            help="Import names to consider as application specific",
+            parse_from_config=True,
+            comma_separated_list=True,
         )
-        parser.add_option(
+        register_opt(
+            parser,
             "--import-order-style",
             default=DEFAULT_IMPORT_ORDER_STYLE,
             action="store",
             type="string",
             help=("Style to follow. Available: "
-                  "cryptography, google, smarkets, pep8")
+                  "cryptography, google, smarkets, pep8"),
+            parse_from_config=True,
         )
-        parser.config_options.append("application-import-names")
-        parser.config_options.append("import-order-style")
 
     @classmethod
     def parse_options(cls, options):
         optdict = {}
 
-        names = options.application_import_names.split(",")
+        names = options.application_import_names
+        if not isinstance(names, list):
+            names = options.application_import_names.split(",")
+
         optdict = dict(
             application_import_names=[n.strip() for n in names],
             import_order_style=options.import_order_style,
@@ -51,3 +59,17 @@ class Linter(ImportOrderChecker):
     def run(self):
         for error in self.check_order():
             yield error
+
+
+def register_opt(parser, *args, **kwargs):
+    try:
+        # Flake8 3.x registration
+        parser.add_option(*args, **kwargs)
+    except (optparse.OptionError, TypeError):
+        # Flake8 2.x registration
+        parse_from_config = kwargs.pop('parse_from_config', False)
+        kwargs.pop('comma_separated_list', False)
+        kwargs.pop('normalize_paths', False)
+        parser.add_option(*args, **kwargs)
+        if parse_from_config:
+            parser.config_options.append(args[-1].lstrip('-'))


### PR DESCRIPTION
Flake8 3.0.0b1 was released 25 June 2016 and introduces some tiny
breaking changes for plugins. This adds compatibility for both Flake8
2.x and 3.x