### PR TITLE
Add Flake8 trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
     },
 
     classifiers=[
+        "Framework :: Flake8",
         "Intended Audience :: Developers",
         "Development Status :: 4 - Beta",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Flake8 has a trove classifier on PyPI. This should new users
find flake8-import-order on PyPI when they search for Flake8
plugins.