### PR TITLE
Extend case insensitivity to submodules/classes

### DIFF
--- a/flake8_import_order/styles.py
+++ b/flake8_import_order/styles.py
@@ -91,7 +91,8 @@ class Google(Style):
     @staticmethod
     def key(import_):
         modules = [module.lower() for module in import_.modules]
-        return (import_.type, import_.level, modules, import_.names)
+        names = [name.lower() for name in import_.names]
+        return (import_.type, import_.level, modules, names)
 
 
 class AppNexus(Google):
@@ -107,10 +108,9 @@ class Smarkets(Style):
     @staticmethod
     def key(import_):
         modules = [module.lower() for module in import_.modules]
+        names = [name.lower() for name in import_.names]
         return (
-            import_.type, import_.is_from, import_.level, modules,
-            import_.names,
-        )
+            import_.type, import_.is_from, import_.level, modules, names)
 
 
 class Cryptography(Style):

--- a/tests/test_cases/complete_google.py
+++ b/tests/test_cases/complete_google.py
@@ -11,6 +11,7 @@ import X
 from X import *
 from X import A
 from X import b, C, d
+from X import E
 import Y
 from Y import *
 from Y import A

--- a/tests/test_cases/complete_smarkets.py
+++ b/tests/test_cases/complete_smarkets.py
@@ -13,6 +13,7 @@ import Z
 from X import *
 from X import A
 from X import b, C, d
+from X import E
 from Y import *
 from Y import A
 from Y import B, C, D


### PR DESCRIPTION
As mentioned in https://github.com/PyCQA/flake8-import-order/commit/3f371dded0b19dba24e0287786fc615cfe3624cd, Google and Smarkets should be case insensitive when checking alphabetical ordering. Since https://github.com/PyCQA/flake8-import-order/commit/863f4597ab4e0879ee6058fab3f5e5b1df1f3463, this wasn't the case when `from X import Y` was being used.