### PR TITLE
fix import order for from to be caseinsensitive with Google and Smarkets style

### DIFF
--- a/flake8_import_order/styles.py
+++ b/flake8_import_order/styles.py
@@ -91,7 +91,8 @@ class Google(Style):
     @staticmethod
     def key(import_):
         modules = [module.lower() for module in import_.modules]
-        return (import_.type, import_.level, modules, import_.names)
+        names = [name.lower() for name in import_.names]
+        return (import_.type, import_.level, modules, names)
 
 
 class AppNexus(Google):
@@ -107,10 +108,8 @@ class Smarkets(Style):
     @staticmethod
     def key(import_):
         modules = [module.lower() for module in import_.modules]
-        return (
-            import_.type, import_.is_from, import_.level, modules,
-            import_.names,
-        )
+        names = [name.lower() for name in import_.names]
+        return (import_.type, import_.is_from, import_.level, modules, names)
 
 
 class Cryptography(Style):

--- a/tests/test_cases/complete_google.py
+++ b/tests/test_cases/complete_google.py
@@ -7,6 +7,9 @@ from os import path
 import StringIO
 import sys
 
+from W import foo
+from W import FooBar
+
 import X
 from X import *
 from X import A

--- a/tests/test_cases/complete_smarkets.py
+++ b/tests/test_cases/complete_smarkets.py
@@ -10,6 +10,10 @@ from os import path
 import X
 import Y
 import Z
+
+from W import foo
+from W import FooBar
+
 from X import *
 from X import A
 from X import b, C, d


### PR DESCRIPTION
This patch resolves the problem reported in https://github.com/PyCQA/flake8-import-order/issues/80#issuecomment-254607840

* The first commit adds the test which originally fails
* The second commit modifies the code to make the above test pass