### PR TITLE
Make styles able to be extended by users

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,9 @@ the code being developed.  This option is only supported if using the
 * ``edited`` - style as ``smarkets`` only with `import` statements for packages local to your company or organisation coming after `import` statements for third-party packages, see an `example <https://github.com/PyCQA/flake8-import-order/blob/master/tests/test_cases/complete_edited.py>`__
 * ``pep8`` - style that only enforces groups without enforcing the order within the groups
 
+You can also `add your own style <#extending-styles>`_ by extending ``Style``
+class.
+
 Limitations
 -----------
 
@@ -81,6 +84,46 @@ release of Python and hence the results can be misleading. This list
 is also the same for all Python versions because otherwise it would
 be impossible to write programs that work under both Python 2 and 3
 *and* pass the import order check.
+
+Extending styles
+----------------
+
+You can add your own style by extending ``flake8_import_order.styles.Style``
+class.  Here's an example:
+
+.. code-block:: python
+
+    from flake8_import_order.styles import Cryptography
+
+
+    class ReversedCryptography(Cryptography):
+        # Note that Cryptography is a subclass of Style.
+
+        @staticmethod
+        def sorted_names(names):
+            return reversed(Cryptography.sorted_names(names))
+
+To make flake8-import-order able to discover your extended style, you need to
+register it as ``flake8_import_order.styles`` using setuptools' `entry points
+<https://setuptools.readthedocs.io/en/latest/pkg_resources.html#entry-points>`__
+mechanism:
+
+.. code-block:: python
+
+    # setup.py of your style package
+    setup(
+        name='flake8-import-order-reversed-cryptography',
+        ...,
+        entry_points={
+            'flake8_import_order.styles': [
+                'reversed = reversedcryptography:ReversedCryptography',
+                # 'reversed' is a style name.  You can pass it to
+                # --import-order-style option
+                # 'reversedcryptography:ReversedCryptography' is an import path
+                # of your extended style class.
+            ]
+        }
+    )
 
 .. |Build Status| image:: https://travis-ci.org/PyCQA/flake8-import-order.png?branch=master
    :target: https://travis-ci.org/PyCQA/flake8-import-order

--- a/flake8_import_order/flake8_linter.py
+++ b/flake8_import_order/flake8_linter.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 import optparse
 
+import pkg_resources
+
 from flake8_import_order import __version__
 from flake8_import_order.checker import (
     DEFAULT_IMPORT_ORDER_STYLE, ImportOrderChecker,
@@ -46,10 +48,18 @@ class Linter(ImportOrderChecker):
             default=DEFAULT_IMPORT_ORDER_STYLE,
             action="store",
             type="string",
-            help=("Style to follow. Available: "
-                  "cryptography, google, smarkets, appnexus, pep8"),
+            help=("Style to follow. Available: " +
+                  ", ".join(cls.list_available_styles())),
             parse_from_config=True,
         )
+
+    @staticmethod
+    def list_available_styles():
+        entry_points = pkg_resources.iter_entry_points(
+            'flake8_import_order.styles'
+        )
+        for entry_point in entry_points:
+            yield entry_point.name
 
     @classmethod
     def parse_options(cls, options):

--- a/flake8_import_order/flake8_linter.py
+++ b/flake8_import_order/flake8_linter.py
@@ -2,12 +2,11 @@ from __future__ import absolute_import
 
 import optparse
 
-import pkg_resources
-
 from flake8_import_order import __version__
 from flake8_import_order.checker import (
     DEFAULT_IMPORT_ORDER_STYLE, ImportOrderChecker,
 )
+from flake8_import_order.styles import list_entry_points, lookup_entry_point
 
 
 class Linter(ImportOrderChecker):
@@ -55,11 +54,8 @@ class Linter(ImportOrderChecker):
 
     @staticmethod
     def list_available_styles():
-        entry_points = pkg_resources.iter_entry_points(
-            'flake8_import_order.styles'
-        )
-        for entry_point in entry_points:
-            yield entry_point.name
+        entry_points = list_entry_points()
+        return sorted(entry_point.name for entry_point in entry_points)
 
     @classmethod
     def parse_options(cls, options):
@@ -73,10 +69,12 @@ class Linter(ImportOrderChecker):
         if not isinstance(pkg_names, list):
             pkg_names = options.application_package_names.split(",")
 
+        style_entry_point = lookup_entry_point(options.import_order_style)
+
         optdict = dict(
             application_import_names=[n.strip() for n in names],
             application_package_names=[p.strip() for p in pkg_names],
-            import_order_style=options.import_order_style,
+            import_order_style=style_entry_point,
         )
 
         cls.options = optdict

--- a/flake8_import_order/pylama_linter.py
+++ b/flake8_import_order/pylama_linter.py
@@ -6,6 +6,7 @@ from flake8_import_order import __version__
 from flake8_import_order.checker import (
     DEFAULT_IMPORT_ORDER_STYLE, ImportOrderChecker,
 )
+from flake8_import_order.styles import lookup_entry_point
 
 
 class Linter(ImportOrderChecker, BaseLinter):
@@ -29,10 +30,11 @@ class Linter(ImportOrderChecker, BaseLinter):
     def run(self, path, **meta):
         self.filename = path
         self.tree = None
-        self.options = dict(
-            {'import_order_style': DEFAULT_IMPORT_ORDER_STYLE},
-            **meta
+        meta.setdefault('import_order_style', DEFAULT_IMPORT_ORDER_STYLE)
+        meta['import_order_style'] = lookup_entry_point(
+            meta['import_order_style']
         )
+        self.options = meta
 
         for error in self.check_order():
             yield error

--- a/flake8_import_order/styles.py
+++ b/flake8_import_order/styles.py
@@ -1,5 +1,7 @@
 from collections import namedtuple
 
+from pkg_resources import iter_entry_points
+
 from flake8_import_order import (
     IMPORT_3RD_PARTY, IMPORT_APP, IMPORT_APP_RELATIVE,
 )
@@ -7,6 +9,17 @@ from flake8_import_order import (
 RELATIVE_SET = {IMPORT_APP, IMPORT_APP_RELATIVE}
 
 Error = namedtuple('Error', ['lineno', 'code', 'message'])
+
+
+def list_entry_points():
+    return iter_entry_points('flake8_import_order.styles')
+
+
+def lookup_entry_point(name):
+    try:
+        return next(iter_entry_points('flake8_import_order.styles', name=name))
+    except StopIteration:
+        raise LookupError('Unknown style {}'.format(name))
 
 
 class Style(object):

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setup(
     zip_safe=False,
 
     install_requires=[
-        "pycodestyle"
+        "pycodestyle",
+        "setuptools",
     ],
 
     tests_require=[
@@ -41,6 +42,14 @@ setup(
 
     py_modules=['flake8_import_order'],
     entry_points={
+        'flake8_import_order.styles': [
+            'cryptography = flake8_import_order.styles:Cryptography',
+            'google = flake8_import_order.styles:Google',
+            'pep8 = flake8_import_order.styles:PEP8',
+            'smarkets = flake8_import_order.styles:Smarkets',
+            'appnexus = flake8_import_order.styles:AppNexus',
+            'edited = flake8_import_order.styles:Edited',
+        ],
         'flake8.extension': [
             'I10 = flake8_import_order.flake8_linter:Linter',
         ],

--- a/tests/test_flake8_linter.py
+++ b/tests/test_flake8_linter.py
@@ -3,6 +3,7 @@ import ast
 import pycodestyle
 
 from flake8_import_order.flake8_linter import Linter
+from flake8_import_order.styles import Google
 
 
 def test_parsing():
@@ -20,7 +21,8 @@ def test_parsing():
     options, args = parser.parse_args(argv)
     Linter.parse_options(options)
 
-    assert Linter.options['import_order_style'] == style
+    assert Linter.options['import_order_style'].name == style
+    assert Linter.options['import_order_style'].load() is Google
     assert Linter.options['application_import_names'] == import_names
     assert Linter.options['application_package_names'] == package_names
 

--- a/tests/test_style_cases.py
+++ b/tests/test_style_cases.py
@@ -6,6 +6,7 @@ import re
 import pytest
 
 from flake8_import_order.checker import ImportOrderChecker
+from flake8_import_order.styles import lookup_entry_point
 
 ERROR_RX = re.compile("# ((I[0-9]{3} ?)+) ?.*$")
 
@@ -34,18 +35,19 @@ def _load_test_cases():
         styles = data.splitlines()[0].lstrip('#').strip().split()
         codes = _extract_expected_errors(data)
         tree = ast.parse(data, fullpath)
-        for style in styles:
-            test_cases.append((filename, tree, style, codes))
+        for style_name in styles:
+            style_entry_point = lookup_entry_point(style_name)
+            test_cases.append((filename, tree, style_entry_point, codes))
 
     return test_cases
 
 
-def _checker(filename, tree, style):
+def _checker(filename, tree, style_entry_point):
     options = {
         'application_import_names': ['flake8_import_order', 'tests'],
-        'import_order_style': style,
+        'import_order_style': style_entry_point,
     }
-    if style in ['appnexus', 'edited']:
+    if style_entry_point.name in ['appnexus', 'edited']:
         options['application_package_names'] = ['localpackage']
     checker = ImportOrderChecker(filename, tree)
     checker.options = options

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,9 @@ deps =
 commands = flake8 flake8_import_order/
 
 [testenv:setuppy]
-deps = docutils
+deps =
+    docutils
+    Pygments
 commands =
     python setup.py check \
         --metadata \

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ deps =
 commands = flake8 flake8_import_order/
 
 [testenv:setuppy]
+basepython = python3.5
 deps =
     docutils
     Pygments


### PR DESCRIPTION
This patch replace hardcoded style names with setuptools' [entry points][1].

> Entry points are a simple way for distributions to “advertise” Python objects (such as functions or classes) for use by other distributions. Extensible applications and frameworks can search for entry points with a particular name or group, either from a specific distribution or from all active distributions on sys.path, and then inspect or load the advertised objects at will.

The group name of extensible entry points is `flake8_import_order.styles` (which follows the convention). Built-in styles also become discovered using entry points so that style names don't have to be hardcoded.

Also wrote some docs about extending styles into README.rst, but I'm unsure that my English is fine. If anyone reviews my code and docs I would adjust the patch.

Thanks for the very useful program! :+1:

[1]: https://setuptools.readthedocs.io/en/latest/pkg_resources.html#entry-points