### PR TITLE
Enable application-package-names for pep8 style

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ company or organisation, but which are obtained using some sort of
 package manager like Pip, Apt, or Yum.  Typically, code representing the
 values listed in this option is located in a different repository than
 the code being developed.  This option is only supported if using the
-``appnexus`` or ``edited`` styles.
+``appnexus``, ``edited``, or ``pep8`` styles.
 
 ``import-order-style`` controls what style the plugin follows
 (``cryptography`` is the default):

--- a/flake8_import_order/checker.py
+++ b/flake8_import_order/checker.py
@@ -40,8 +40,8 @@ class ImportOrderChecker(object):
             style_entry_point = lookup_entry_point(DEFAULT_IMPORT_ORDER_STYLE)
 
         # application_package_names is supported only for the
-        # 'appnexus' and 'edited' styles
-        if style_entry_point.name in ['appnexus', 'edited']:
+        # 'appnexus', 'edited', and 'pep8' styles
+        if style_entry_point.name in ['appnexus', 'edited', 'pep8']:
             visitor = self.visitor_class(
                 self.options.get('application_import_names', []),
                 self.options.get('application_package_names', []),


### PR DESCRIPTION
For networking-midonet project, [1] we want to use pep8 style
with an additional group of modules. [2]
application-package-names seems to fit our needs well.  I think
it can be used for the rest of OpenStack projects as well.

While this can be a dedicated style, I don't think it's worth
doing it, given that it's compatible with the existing behaviour
as far as application-package-names is left to be empty, which
is the default.

[1] https://docs.openstack.org/networking-midonet/latest/
[2] https://review.openstack.org/#/c/482450/1/tox.ini@86