### PR TITLE
Support application_package_names in pep8 style

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,8 +57,8 @@ company or organisation, but which are obtained using some sort of
 package manager like Pip, Apt, or Yum.  Typically, code representing
 the values listed in this option is located in a different repository
 than the code being developed.  This option is only accepted in the
-supported ``appnexus`` or ``edited`` styles or in any style that
-accepts application package names.
+supported ``appnexus``, ``edited`` or ``pep8`` styles or in any style
+that accepts application package names.
 
 ``import-order-style`` controls what style the plugin follows
 (``cryptography`` is the default).

--- a/flake8_import_order/styles.py
+++ b/flake8_import_order/styles.py
@@ -97,7 +97,7 @@ class Style(object):
 
 
 class PEP8(Style):
-    pass
+    accepts_application_package_names = True
 
 
 class Google(Style):


### PR DESCRIPTION
application_package_names option is useful even when pep8 style is
used. If the option is not set, the previous behavior is not changed.