### PR TITLE
Allow styles an ability to override the actual checks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ The following styles are directly supported,
 * ``google`` - style described in `Google Style Guidelines <https://google.github.io/styleguide/pyguide.html?showone=Imports_formatting#Imports_formatting>`__, see an `example <https://github.com/PyCQA/flake8-import-order/blob/master/tests/test_cases/complete_google.py>`__
 * ``smarkets`` - style as ``google`` only with `import` statements before `from X import ...` statements, see an `example <https://github.com/PyCQA/flake8-import-order/blob/master/tests/test_cases/complete_smarkets.py>`__
 * ``appnexus`` - style as ``google`` only with `import` statements for packages local to your company or organisation coming after `import` statements for third-party packages, see an `example <https://github.com/PyCQA/flake8-import-order/blob/master/tests/test_cases/complete_appnexus.py>`__
-* ``edited`` - style as ``smarkets`` only with `import` statements for packages local to your company or organisation coming after `import` statements for third-party packages and that the `import` and `from X import` statements may or may not be separated by a newline, see an `example <https://github.com/PyCQA/flake8-import-order/blob/master/tests/test_cases/complete_edited.py>`__
+* ``edited`` - ssee an `example <https://github.com/PyCQA/flake8-import-order/blob/master/tests/test_cases/complete_edited.py>`__
 * ``pep8`` - style that only enforces groups without enforcing the order within the groups
 
 You can also `add your own style <#extending-styles>`_ by extending ``Style``

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ The following styles are directly supported,
 * ``google`` - style described in `Google Style Guidelines <https://google.github.io/styleguide/pyguide.html?showone=Imports_formatting#Imports_formatting>`__, see an `example <https://github.com/PyCQA/flake8-import-order/blob/master/tests/test_cases/complete_google.py>`__
 * ``smarkets`` - style as ``google`` only with `import` statements before `from X import ...` statements, see an `example <https://github.com/PyCQA/flake8-import-order/blob/master/tests/test_cases/complete_smarkets.py>`__
 * ``appnexus`` - style as ``google`` only with `import` statements for packages local to your company or organisation coming after `import` statements for third-party packages, see an `example <https://github.com/PyCQA/flake8-import-order/blob/master/tests/test_cases/complete_appnexus.py>`__
-* ``edited`` - style as ``smarkets`` only with `import` statements for packages local to your company or organisation coming after `import` statements for third-party packages, see an `example <https://github.com/PyCQA/flake8-import-order/blob/master/tests/test_cases/complete_edited.py>`__
+* ``edited`` - style as ``smarkets`` only with `import` statements for packages local to your company or organisation coming after `import` statements for third-party packages and that the `import` and `from X import` statements may or may not be separated by a newline, see an `example <https://github.com/PyCQA/flake8-import-order/blob/master/tests/test_cases/complete_edited.py>`__
 * ``pep8`` - style that only enforces groups without enforcing the order within the groups
 
 You can also `add your own style <#extending-styles>`_ by extending ``Style``

--- a/flake8_import_order/styles.py
+++ b/flake8_import_order/styles.py
@@ -219,6 +219,10 @@ class Edited(Smarkets):
                 ),
             )
 
+    @staticmethod
+    def same_section(previous, current):
+        return current.type == previous.type
+
 
 class Cryptography(Style):
 

--- a/tests/test_cases/additional_newline_edited.py
+++ b/tests/test_cases/additional_newline_edited.py
@@ -1,4 +1,4 @@
-# appnexus google pep8 smarkets
+# edited
 import ast
 # This comment should not trigger a I202 (not a newline)
 import os
@@ -19,6 +19,7 @@ from Z import A
 import flake8_import_order
 
 import tests  # I202
+
 from . import A
 
 from . import B  # I202

--- a/tests/test_cases/complete_edited.py
+++ b/tests/test_cases/complete_edited.py
@@ -23,6 +23,7 @@ from Z.A import A
 from Z.A.B import A
 
 import localpackage
+
 from localpackage import A, b
 
 import flake8_import_order

--- a/tests/test_cases/complete_edited.py
+++ b/tests/test_cases/complete_edited.py
@@ -28,6 +28,7 @@ from localpackage import A, b
 
 import flake8_import_order
 from flake8_import_order import *
+
 from . import A
 from . import B
 from .A import A


### PR DESCRIPTION
This is specifically helpful to allow the edited style to have an
optional newline between ``import`` and ``form X import`` lines
without triggering a I202 error.

In a more general sense this should allow for more advanced styles.