### PR TITLE
Add support for "priority" import names

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,9 +61,15 @@ than the code being developed.  This option is only accepted in the
 supported ``appnexus`` or ``edited`` styles or in any style that
 accepts application package names.
 
-The ``application-import-names`` and ``application-package-names`` can
-contain namespaced packages or even exact nested module names. (This
-is possible with 0.16 onwards).
+You can also set the ``priority-import-names`` option to a comma
+separated list of names that will be considered "priority" imports.
+These names are allowed to appear *before* the standard library
+grouping, making it easier to apply custom behavior (e.g. monkey
+patches) to subsequent import statements.
+
+The ``application-import-names``, ``application-package-names``, and
+``priority-import-names`` options can contain namespaced packages or
+even exact nested module names. (This is possible with 0.16 onwards).
 
 ``import-order-style`` controls what style the plugin follows
 (``cryptography`` is the default).

--- a/flake8_import_order/checker.py
+++ b/flake8_import_order/checker.py
@@ -61,11 +61,13 @@ class ImportOrderChecker(object):
             visitor = self.visitor_class(
                 self.options.get('application_import_names', []),
                 self.options.get('application_package_names', []),
+                self.options.get('priority_import_names', []),
             )
         else:
             visitor = self.visitor_class(
                 self.options.get('application_import_names', []),
                 [],
+                self.options.get('priority_import_names', []),
             )
         visitor.visit(self.tree)
 

--- a/flake8_import_order/flake8_linter.py
+++ b/flake8_import_order/flake8_linter.py
@@ -51,6 +51,16 @@ class Linter(ImportOrderChecker):
                   ", ".join(cls.list_available_styles())),
             parse_from_config=True,
         )
+        register_opt(
+            parser,
+            "--priority-import-names",
+            default="",
+            action="store",
+            type="string",
+            help=("Import names to consider as high priority (before stdlib)"),
+            parse_from_config=True,
+            comma_separated_list=True,
+        )
 
     @staticmethod
     def list_available_styles():
@@ -69,12 +79,17 @@ class Linter(ImportOrderChecker):
         if not isinstance(pkg_names, list):
             pkg_names = options.application_package_names.split(",")
 
+        priority_names = options.priority_import_names
+        if not isinstance(priority_names, list):
+            priority_names = options.priority_import_names.split(",")
+
         style_entry_point = lookup_entry_point(options.import_order_style)
 
         optdict = dict(
             application_import_names=[n.strip() for n in names],
             application_package_names=[p.strip() for p in pkg_names],
             import_order_style=style_entry_point,
+            priority_import_names=[p.strip() for p in priority_names],
         )
 
         cls.options = optdict

--- a/tests/test_cases/priority.py
+++ b/tests/test_cases/priority.py
@@ -1,0 +1,4 @@
+# appnexus cryptography google pep8 smarkets
+import priority
+
+import socket

--- a/tests/test_flake8_linter.py
+++ b/tests/test_flake8_linter.py
@@ -10,10 +10,12 @@ def test_parsing():
     style = 'google'
     import_names = ['flake8_import_order', 'tests']
     package_names = ['local_package']
+    priority_names = ['priority']
     argv = [
         "--application-import-names={}".format(','.join(import_names)),
         "--import-order-style={}".format(style),
         "--application-package-names={}".format(','.join(package_names)),
+        "--priority-import-names={}".format(','.join(priority_names)),
     ]
 
     parser = pycodestyle.get_parser('', '')
@@ -25,6 +27,7 @@ def test_parsing():
     assert Linter.options['import_order_style'].load() is Google
     assert Linter.options['application_import_names'] == import_names
     assert Linter.options['application_package_names'] == package_names
+    assert Linter.options['priority_import_names'] == priority_names
 
 
 def test_linter():

--- a/tests/test_style_cases.py
+++ b/tests/test_style_cases.py
@@ -53,6 +53,7 @@ def _checker(filename, tree, style_entry_point):
         ],
         'application_package_names': ['localpackage'],
         'import_order_style': style_entry_point,
+        'priority_import_names': ['priority'],
     }
     checker = ImportOrderChecker(filename, tree)
     checker.options = options


### PR DESCRIPTION
You can set the ``priority-import-names`` option to a comma separated
list of names that will be considered "priority" imports. These names
are allowed to appear *before* the standard library grouping, making it
easier to apply custom behavior (e.g. monkey patches) to subsequent
import statements.

For example:

```python
import gevent.monkey
gevent.monkey.patch_all()

import socket
```

There doesn't appear to be another way to support this pattern. The error
would appear on the `import socket` line above, and that's not the correct
place to add a `#noqa` annotation.

I don't love the name "priority" for this. I also considered "early", but that's
equally ambiguous. I'm more than happy to rename this to something else.