### PR TITLE
Simplify re group access

### DIFF
--- a/flake8_import_order/checker.py
+++ b/flake8_import_order/checker.py
@@ -90,7 +90,7 @@ class ImportOrderChecker(object):
         if noqa_match is None:
             return False
 
-        codes_str = noqa_match.groupdict()['codes']
+        codes_str = noqa_match.group('codes')
         if codes_str is None:
             return True
 


### PR DESCRIPTION
`.group(name)` is more straightforward than `.groupdict()[name]`.