### PR TITLE
Fix case-sensitive related I100 errors for the pycharm style.

### DIFF
--- a/flake8_import_order/styles.py
+++ b/flake8_import_order/styles.py
@@ -229,6 +229,10 @@ class PyCharm(Smarkets):
     def sorted_names(names):
         return sorted(names)
 
+    @staticmethod
+    def import_key(import_):
+        return (import_.type, import_.is_from, import_.level, import_.modules, import_.names)
+
 
 class Cryptography(Style):
 

--- a/tests/test_cases/complete_pycharm.py
+++ b/tests/test_cases/complete_pycharm.py
@@ -1,0 +1,35 @@
+# pycharm
+from __future__ import absolute_import
+
+import StringIO
+import ast
+import os
+import sys
+from functools import *
+from os import path
+
+import X
+import Y
+import Z
+import localpackage
+from X import *
+from X import A
+from X import B, C, b, d
+from Y import *
+from Y import A
+from Y import B, C, D
+from Y import e
+from Z import A
+from Z.A import A
+from Z.A.B import A
+
+import flake8_import_order
+from flake8_import_order import *
+from . import A
+from . import B
+from .A import A
+from .B import B
+from .. import A
+from .. import B
+from ..A import A
+from ..B import B


### PR DESCRIPTION
Pycharm sorts imports over multiple line case-sensitive.
The following should be a valid import order.

  import B
  import a

Also added a pycharm test case.

Closes-issue: #158