### PR TITLE
Fix warning in noqa regexp

### DIFF
--- a/flake8_import_order/checker.py
+++ b/flake8_import_order/checker.py
@@ -18,7 +18,7 @@ NOQA_INLINE_REGEXP = re.compile(
     # We do not care about the ``: `` that follows ``noqa``
     # We do not care about the casing of ``noqa``
     # We want a comma-separated list of errors
-    '# noqa(?:: (?P<codes>([A-Z][0-9]+(?:[,\s]+)?)+))?',
+    r'# noqa(?:: (?P<codes>([A-Z][0-9]+(?:[,\s]+)?)+))?',
     re.IGNORECASE
 )
 COMMA_SEPARATED_LIST_RE = re.compile(r'[,\s]')


### PR DESCRIPTION
Regular expression for finding `# noqa` comments produces `DeprecationWarning: invalid escape sequence \s` when installing flake8-import-order as a requirement in setup.py. This line also fails `pycodestyle` check with message `W605 - invalid escape sequence '\s'`.
Environment to reproduce - python3.7, setuptools 39.0.1.