### PR TITLE
Allow adding modules to be considered as part of the Standard Library

### DIFF
--- a/flake8_import_order/__init__.py
+++ b/flake8_import_order/__init__.py
@@ -65,10 +65,14 @@ def root_package_name(name):
 
 class ImportVisitor(ast.NodeVisitor):
 
-    def __init__(self, application_import_names, application_package_names):
+    def __init__(self,
+                 application_import_names,
+                 application_package_names,
+                 additional_stdlib_names):
         self.imports = []
         self.application_import_names = frozenset(application_import_names)
         self.application_package_names = frozenset(application_package_names)
+        self.stdlib_names = STDLIB_NAMES | frozenset(additional_stdlib_names)
 
     def visit_Import(self, node):  # noqa: N802
         if node.col_offset == 0:
@@ -111,7 +115,7 @@ class ImportVisitor(ast.NodeVisitor):
                 return ImportType.APPLICATION
             elif package in self.application_package_names:
                 return ImportType.APPLICATION_PACKAGE
-            elif package in STDLIB_NAMES:
+            elif package in self.stdlib_names:
                 return ImportType.STDLIB
 
         # Not future, stdlib or an application import.

--- a/flake8_import_order/checker.py
+++ b/flake8_import_order/checker.py
@@ -61,11 +61,13 @@ class ImportOrderChecker(object):
             visitor = self.visitor_class(
                 self.options.get('application_import_names', []),
                 self.options.get('application_package_names', []),
+                self.options.get('additional_stdlib_names', []),
             )
         else:
             visitor = self.visitor_class(
                 self.options.get('application_import_names', []),
                 [],
+                self.options.get('additional_stdlib_names', []),
             )
         visitor.visit(self.tree)
 

--- a/flake8_import_order/flake8_linter.py
+++ b/flake8_import_order/flake8_linter.py
@@ -51,6 +51,17 @@ class Linter(ImportOrderChecker):
                   ", ".join(cls.list_available_styles())),
             parse_from_config=True,
         )
+        register_opt(
+            parser,
+            "--additional-stdlib-names",
+            default="",
+            action="store",
+            type="string",
+            help=("Additional import names to be considered as part of "
+                  "the standard library for the purposes of grouping."),
+            parse_from_config=True,
+            comma_separated_list=True,
+        )
 
     @staticmethod
     def list_available_styles():
@@ -69,12 +80,20 @@ class Linter(ImportOrderChecker):
         if not isinstance(pkg_names, list):
             pkg_names = options.application_package_names.split(",")
 
+        additional_stdlib_names = options.additional_stdlib_names
+        if not isinstance(additional_stdlib_names, list):
+            additional_stdlib_names = options.additional_stdlib_names \
+                                             .split(",")
+
+        additional_stdlib_names = [s.strip() for s in additional_stdlib_names]
+
         style_entry_point = lookup_entry_point(options.import_order_style)
 
         optdict = dict(
             application_import_names=[n.strip() for n in names],
             application_package_names=[p.strip() for p in pkg_names],
             import_order_style=style_entry_point,
+            additional_stdlib_names=additional_stdlib_names,
         )
 
         cls.options = optdict

--- a/tests/test_cases/complete_appnexus.py
+++ b/tests/test_cases/complete_appnexus.py
@@ -1,6 +1,7 @@
 # appnexus
 from __future__ import absolute_import
 
+import additional_stdlib
 import ast
 from functools import *
 import os

--- a/tests/test_cases/complete_cryptography.py
+++ b/tests/test_cases/complete_cryptography.py
@@ -1,6 +1,7 @@
 # cryptography
 from __future__ import absolute_import
 
+import additional_stdlib
 import ast
 import os
 import sys

--- a/tests/test_cases/complete_edited.py
+++ b/tests/test_cases/complete_edited.py
@@ -1,6 +1,7 @@
 # edited
 from __future__ import absolute_import
 
+import additional_stdlib
 import ast
 import os
 import StringIO

--- a/tests/test_cases/complete_google.py
+++ b/tests/test_cases/complete_google.py
@@ -1,6 +1,7 @@
 # google
 from __future__ import absolute_import
 
+import additional_stdlib
 import ast
 from functools import *
 import os

--- a/tests/test_cases/complete_pep8.py
+++ b/tests/test_cases/complete_pep8.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 import sys
 from os import path
 import os
+import additional_stdlib
 from functools import *
 import ast
 

--- a/tests/test_cases/complete_pycharm.py
+++ b/tests/test_cases/complete_pycharm.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 import StringIO
+import additional_stdlib
 import ast
 import os
 import sys

--- a/tests/test_cases/complete_smarkets.py
+++ b/tests/test_cases/complete_smarkets.py
@@ -1,6 +1,7 @@
 # smarkets
 from __future__ import absolute_import
 
+import additional_stdlib
 import ast
 import os
 import StringIO

--- a/tests/test_cases/wrong_section.py
+++ b/tests/test_cases/wrong_section.py
@@ -4,5 +4,6 @@ import ast
 import flake8_import_order # I100
 
 import A
+import additional_stdlib # I100
 
-import os # I100
+import os # I201 I202

--- a/tests/test_cases/wrong_section_appnexus.py
+++ b/tests/test_cases/wrong_section_appnexus.py
@@ -2,4 +2,5 @@
 import ast
 import flake8_import_order # I201 I100
 import localpackage # I201 I100
+import additional_stdlib # I201
 import X # I201

--- a/tests/test_flake8_linter.py
+++ b/tests/test_flake8_linter.py
@@ -10,10 +10,12 @@ def test_parsing():
     style = 'google'
     import_names = ['flake8_import_order', 'tests']
     package_names = ['local_package']
+    additional_stdlib = ['additional_stdlib']
     argv = [
         "--application-import-names={}".format(','.join(import_names)),
         "--import-order-style={}".format(style),
         "--application-package-names={}".format(','.join(package_names)),
+        "--additional-stdlib-names={}".format(','.join(additional_stdlib)),
     ]
 
     parser = pycodestyle.get_parser('', '')
@@ -25,6 +27,7 @@ def test_parsing():
     assert Linter.options['import_order_style'].load() is Google
     assert Linter.options['application_import_names'] == import_names
     assert Linter.options['application_package_names'] == package_names
+    assert Linter.options['additional_stdlib_names'] == additional_stdlib
 
 
 def test_linter():

--- a/tests/test_style_cases.py
+++ b/tests/test_style_cases.py
@@ -53,6 +53,7 @@ def _checker(filename, tree, style_entry_point):
         ],
         'application_package_names': ['localpackage'],
         'import_order_style': style_entry_point,
+        'additional_stdlib_names': ['additional_stdlib'],
     }
     checker = ImportOrderChecker(filename, tree)
     checker.options = options


### PR DESCRIPTION
Hi there!

One helpful feature I've seen is to allow for custom modules/packages to be considered as part of the standard library for the purposes of grouping.

This pull request allows for an additional configuration option to accomplish that.

Tests have been updated to accommodate this new functionality.