### PR TITLE
Python 3.8 raises TypeError if plugin not configured

### DIFF
--- a/flake8_import_order/checker.py
+++ b/flake8_import_order/checker.py
@@ -55,6 +55,8 @@ class ImportOrderChecker(object):
             style_entry_point = self.options['import_order_style']
         except KeyError:
             style_entry_point = lookup_entry_point(DEFAULT_IMPORT_ORDER_STYLE)
+        except TypeError:
+            style_entry_point = lookup_entry_point(DEFAULT_IMPORT_ORDER_STYLE)
         style_cls = style_entry_point.load()
 
         if style_cls.accepts_application_package_names:


### PR DESCRIPTION
Running with python3.8 I see:

```flake8  test
multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/Users/metson/code/seed/venv/lib/python3.8/site-packages/flake8/checker.py", line 666, in _run_checks
    return checker.run_checks()
  File "/Users/metson/code/seed/venv/lib/python3.8/site-packages/flake8/checker.py", line 598, in run_checks
    self.run_ast_checks()
  File "/Users/metson/code/seed/venv/lib/python3.8/site-packages/flake8/checker.py", line 502, in run_ast_checks
    for (line_number, offset, text, check) in runner:
  File "/Users/metson/code/seed/venv/lib/python3.8/site-packages/flake8_import_order/flake8_linter.py", line 91, in run
    for error in self.check_order():
  File "/Users/metson/code/seed/venv/lib/python3.8/site-packages/flake8_import_order/checker.py", line 55, in check_order
    style_entry_point = self.options['import_order_style']
TypeError: 'NoneType' object is not subscriptable
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/metson/code/seed/venv/bin/flake8", line 8, in <module>
    sys.exit(main())
  File "/Users/metson/code/seed/venv/lib/python3.8/site-packages/flake8/main/cli.py", line 18, in main
    app.run(argv)
  File "/Users/metson/code/seed/venv/lib/python3.8/site-packages/flake8/main/application.py", line 393, in run
    self._run(argv)
  File "/Users/metson/code/seed/venv/lib/python3.8/site-packages/flake8/main/application.py", line 381, in _run
    self.run_checks()
  File "/Users/metson/code/seed/venv/lib/python3.8/site-packages/flake8/main/application.py", line 300, in run_checks
    self.file_checker_manager.run()
  File "/Users/metson/code/seed/venv/lib/python3.8/site-packages/flake8/checker.py", line 329, in run
    self.run_parallel()
  File "/Users/metson/code/seed/venv/lib/python3.8/site-packages/flake8/checker.py", line 293, in run_parallel
    for ret in pool_map:
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/multiprocessing/pool.py", line 865, in next
    raise value
TypeError: 'NoneType' object is not subscriptable
make: *** [flake8] Error 1```

I'm not sure if this is the best fix - the exception might point to an underlying problem - but seems like a good quick fix.