### PR TITLE
Cap for pycodestyle to avoid un-noticed break

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
 
     install_requires=[
         "enum34 ;  python_version <= '2.7'",
-        "pycodestyle",
+        "pycodestyle >= 2.6.0a1, < 2.7.0",
         "setuptools",
     ],
 


### PR DESCRIPTION
For pycodestyle new releases , we can manually update to the new pycodestyle by
making sure everything is fine.