### PR TITLE
Recognize zoneinfo introduced in python 3.9 as stdlib

### DIFF
--- a/flake8_import_order/stdlib_list.py
+++ b/flake8_import_order/stdlib_list.py
@@ -316,4 +316,5 @@ STDLIB_NAMES = {
     "zipfile",
     "zipimport",
     "zlib",
+    "zoneinfo",
 }

--- a/tests/test_stdlib.py
+++ b/tests/test_stdlib.py
@@ -26,7 +26,7 @@ def _checker(data):
 
 @pytest.mark.parametrize('import_name', _load_test_cases())
 def test_styles(import_name):
-    data = "import {}\nimport zlib\n".format(import_name)
+    data = "import {}\nimport zoneinfo\n".format(import_name)
     checker = _checker(data)
     codes = [error.code for error in checker.check_order()]
     assert codes == []


### PR DESCRIPTION
Please tag a new release with this change