### PR TITLE
GitHub Action to run tox to replace Travis CI

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,0 +1,17 @@
+name: tox
+on: [push, pull_request]
+jobs:
+  tox-jobs:
+    strategy:
+      fail-fast: false
+      matrix:
+        job: [py37-flake83]  # ,pypy,pep8,py3pep8,setuppy,manifest]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+      - run: pip install --upgrade pip
+      - run: pip install tox
+      - run: tox -e ${{ matrix.job }}


### PR DESCRIPTION
Test results: https://github.com/cclauss/flake8-import-order/actions

https://travis-ci.org/github/PyCQA/flake8-import-order/builds