### PR TITLE
Add I301 check, for TYPE_CHECKING too far from previous import

### DIFF
--- a/flake8_import_order/styles.py
+++ b/flake8_import_order/styles.py
@@ -48,6 +48,7 @@ class Style:
             and current_import.type_checking
         ):
             yield from self._check_I300(previous_import, current_import)
+            yield from self._check_I301(previous_import, current_import)
             previous_import = None
         if previous_import is not None:
             yield from self._check_I100(previous_import, current_import)
@@ -78,11 +79,19 @@ class Style:
             )
 
     def _check_I300(self, previous_import, current_import):  # noqa: N802
-        if current_import.lineno - previous_import.end_lineno != 3:
+        if current_import.lineno - previous_import.end_lineno < 3:
             yield Error(
                 current_import.lineno,
                 "I300",
                 "TYPE_CHECKING block should have one newline above.",
+            )
+
+    def _check_I301(self, previous_import, current_import):  # noqa: N802
+        if current_import.lineno - previous_import.end_lineno > 3:
+            yield Error(
+                current_import.lineno,
+                "I301",
+                "TYPE_CHECKING block should have no more than one newline above.",
             )
 
     def _check_I100(self, previous_import, current_import):  # noqa: N802

--- a/tests/test_cases/type_checking_orphaned.py
+++ b/tests/test_cases/type_checking_orphaned.py
@@ -1,0 +1,11 @@
+# cryptography edited google pep8 smarkets
+from typing import TYPE_CHECKING
+
+import pytest
+
+from . import localpackage
+
+CONST = localpackage.CONST
+
+if TYPE_CHECKING:
+    import ast  # I301


### PR DESCRIPTION
Follow-up to suggested new check in https://github.com/PyCQA/flake8-import-order/issues/214#issuecomment-2982343562. Thanks to the testing framework already in place, I'm _reasonably_ confident that this has no unintended side-effects. 😁

The new code `I301` covers both "too many newlines" and "non-import stuff between the other imports and TYPE_CHECKING" cases. (This way was cleaner than trying to keep track of the `previous_non_import` node, which would complicate the iterator.)